### PR TITLE
Add version bump workflows; update package scopes

### DIFF
--- a/.github/workflows/ci_bump_libkernel.yml
+++ b/.github/workflows/ci_bump_libkernel.yml
@@ -1,0 +1,35 @@
+name: "CI - Bump libkernel"
+
+on:
+  workflow_dispatch:
+    # Inputs the workflow accepts.
+    inputs:
+      version:
+        # Friendly description to be shown in the UI instead of 'name'
+        description: "Semver type of new version (major / minor / patch)"
+        # Input has to be provided for the workflow to run
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+defaults:
+  run:
+    working-directory: "libs/libkernel"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    outputs:
+      steps:
+        - uses: actions/checkout@v3
+        - name: "NPM Version Publish"
+          id: version
+          uses: "SkynetLabs/.github/.github/actions/npm-version-publish@marcins/sky-1032-add-shared-workflow-for-npm-publish"
+          with:
+            github-token: ${{ secrets.GITHUB_TOKEN }}
+            npm-token: ${{ secrets.NPM_TOKEN }}
+            version-bump: ${{ github.event.inputs.version }}
+            tag-prefix: "libkernel-v"


### PR DESCRIPTION
# PULL REQUEST

## Overview

- [ ] Add workflows for manually bumping the version
  - [ ] Needs testing
  - [ ] Do we also need this for the packages in `modules`?

Depends on: https://github.com/SkynetLabs/.github/pull/34 (shared workflow for npm publish)

## Issues Closed

<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->

Closes SKY-1034