### PR TITLE
Encoding and seed jest and extensions

### DIFF
--- a/libs/libskynet/jest.config.js
+++ b/libs/libskynet/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 export default {
   preset: "ts-jest",
+  resolver: "jest-ts-webcompat-resolver",
   testEnvironment: "node",
   testPathIgnorePatterns: [
     "src-test/test.ts", // Don't run legacy tests with Jest

--- a/libs/libskynet/package-lock.json
+++ b/libs/libskynet/package-lock.json
@@ -13,6 +13,7 @@
 				"@typescript-eslint/eslint-plugin": "^5.19.0",
 				"eslint": "^8.13.0",
 				"jest": "^28.1.2",
+				"jest-ts-webcompat-resolver": "^1.0.0",
 				"prettier": "^2.6.2",
 				"skynet-js": "^4.3.0",
 				"ts-jest": "^28.0.5",
@@ -3405,6 +3406,15 @@
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+			}
+		},
+		"node_modules/jest-ts-webcompat-resolver": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/jest-ts-webcompat-resolver/-/jest-ts-webcompat-resolver-1.0.0.tgz",
+			"integrity": "sha512-BFoaU7LeYqZNnTYEr6iMRf87xdCQntNc/Wk8YpzDBcuz+CIZ0JsTtzuMAMnKiEgTRTC1wRWLUo2RlVjVijBcHQ==",
+			"dev": true,
+			"peerDependencies": {
+				"jest-resolve": "*"
 			}
 		},
 		"node_modules/jest-util": {
@@ -7532,6 +7542,13 @@
 				"pretty-format": "^28.1.1",
 				"semver": "^7.3.5"
 			}
+		},
+		"jest-ts-webcompat-resolver": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/jest-ts-webcompat-resolver/-/jest-ts-webcompat-resolver-1.0.0.tgz",
+			"integrity": "sha512-BFoaU7LeYqZNnTYEr6iMRf87xdCQntNc/Wk8YpzDBcuz+CIZ0JsTtzuMAMnKiEgTRTC1wRWLUo2RlVjVijBcHQ==",
+			"dev": true,
+			"requires": {}
 		},
 		"jest-util": {
 			"version": "28.1.1",

--- a/libs/libskynet/package.json
+++ b/libs/libskynet/package.json
@@ -25,6 +25,7 @@
 		"@typescript-eslint/eslint-plugin": "^5.19.0",
 		"eslint": "^8.13.0",
 		"jest": "^28.1.2",
+		"jest-ts-webcompat-resolver": "^1.0.0",
 		"prettier": "^2.6.2",
 		"skynet-js": "^4.3.0",
 		"ts-jest": "^28.0.5",

--- a/libs/libskynet/src/ed25519.ts
+++ b/libs/libskynet/src/ed25519.ts
@@ -1,5 +1,5 @@
-import { addContextToErr } from "./err";
-import { sha512internal } from "./sha512";
+import { addContextToErr } from "./err.js";
+import { sha512internal } from "./sha512.js";
 
 const crypto_sign_BYTES = 64,
   crypto_sign_PUBLICKEYBYTES = 32,

--- a/libs/libskynet/src/encoding.ts
+++ b/libs/libskynet/src/encoding.ts
@@ -1,5 +1,5 @@
-import { addContextToErr } from "./err";
-import { Err } from "./types";
+import { addContextToErr } from "./err.js";
+import { Err } from "./types.js";
 
 const MAX_UINT_64 = 18446744073709551615n
 

--- a/libs/libskynet/src/err.ts
+++ b/libs/libskynet/src/err.ts
@@ -1,4 +1,4 @@
-import { objAsString } from "./objAsString";
+import { objAsString } from "./objAsString.js";
 
 // addContextToErr is a helper function that standardizes the formatting of
 // adding context to an error.

--- a/libs/libskynet/src/index.ts
+++ b/libs/libskynet/src/index.ts
@@ -1,5 +1,5 @@
-export { DICTIONARY_UNIQUE_PREFIX, dictionary } from "./dictionary";
-export { Ed25519Keypair, ed25519KeypairFromEntropy, ed25519Sign, ed25519Verify } from "./ed25519";
+export { DICTIONARY_UNIQUE_PREFIX, dictionary } from "./dictionary.js";
+export { Ed25519Keypair, ed25519KeypairFromEntropy, ed25519Sign, ed25519Verify } from "./ed25519.js";
 export {
   b64ToBuf,
   bufToHex,

--- a/libs/libskynet/src/seed.ts
+++ b/libs/libskynet/src/seed.ts
@@ -1,7 +1,7 @@
-import { DICTIONARY_UNIQUE_PREFIX, dictionary } from "./dictionary";
-import { Ed25519Keypair, ed25519KeypairFromEntropy } from "./ed25519";
-import { sha512 } from "./sha512";
-import { addContextToErr } from "./err";
+import { DICTIONARY_UNIQUE_PREFIX, dictionary } from "./dictionary.js";
+import { Ed25519Keypair, ed25519KeypairFromEntropy } from "./ed25519.js";
+import { sha512 } from "./sha512.js";
+import { addContextToErr } from "./err.js";
 
 // Define the number of entropy words used when generating the seed.
 const SEED_ENTROPY_WORDS = 13;


### PR DESCRIPTION
## Overview
* Brings back `.js` extensions to the source code
* Makes tests work with `.js` extensions
* ⚠️ Targets #250 